### PR TITLE
Use CBA Settings System instead of modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ $RECYCLE.BIN/
 
 # Mac desktop service store files
 .DS_Store
+
+.vscode

--- a/dev/bft/CfgFunctions.hpp
+++ b/dev/bft/CfgFunctions.hpp
@@ -19,6 +19,7 @@ class CfgFunctions {
             file = FUNCFILE(main);
 
             class init {};
+            class initClient {};
             class initModule {};
             class initAssign {};
             class initModuleAssign {};

--- a/dev/bft/CfgVehicles.hpp
+++ b/dev/bft/CfgVehicles.hpp
@@ -19,8 +19,8 @@ class CfgVehicles {
     };
 
     class MODULE_BFT: Module_F {
-        scope = 2;
-        displayName = $STR_MODULE_BFT_NAME;
+        scope = 1;
+        displayName = CSTRING(Enable);
         icon = QDATAPATH(icon_module.paa);
         category = QUOTE(MODULE_CATEGORY);
         function = FUNC(initModule);

--- a/dev/bft/Extended_Eventhandlers.hpp
+++ b/dev/bft/Extended_Eventhandlers.hpp
@@ -5,3 +5,8 @@ class Extended_Put_Eventhandlers {
         };
     };
 };
+class Extended_PreInit_Eventhandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};

--- a/dev/bft/XEH_preInit.sqf
+++ b/dev/bft/XEH_preInit.sqf
@@ -1,0 +1,8 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+#include "initSettings.sqf"
+if (GVAR(enable)) then { [] spawn FUNC(init); };
+
+ADDON = true;

--- a/dev/bft/functions/main/fn_init.sqf
+++ b/dev/bft/functions/main/fn_init.sqf
@@ -2,37 +2,7 @@
 
 GVAR(active) = true;
 
-// Client init
-if(hasInterface) then {
-    waitUntil { !isNull player };
-    waitUntil { !isNull (finddisplay 46) };
-
-    // set player variables
-    player setVariable [QGVAR(drawMarker), false, true];
-    player setVariable [QGVAR(marker), NEW_MARKER, true];
-
-    // GPS
-    if(EGVAR(rft,active)) then {
-        waitUntil { !isNil QEGVAR(rft,pfhGPS); };
-    };
-
-    GVAR(pfhGPS) = [
-        {
-            _finished = false;
-            {
-                if(ctrlIDD _x == 311) then {
-                    _mapControl = _x displayCtrl 101;
-                    _mapControl ctrlAddEventHandler ["draw", FUNC(handleDraw)];
-                    _finished = true;
-                };
-            } forEach (uiNamespace getVariable "IGUI_displays");
-            if(_finished) then {
-                [_this select 1] call CBA_fnc_removePerFrameHandler;
-            };
-        },
-        0,[]
-    ] call CBA_fnc_addPerFrameHandler;
-};
+if (hasInterface) then {[] call FUNC(initClient)};
 
 // Common init
 GVAR(symbols) = [
@@ -73,13 +43,17 @@ GVAR(configureVisible) = false;
 GVAR(configureUnits) = allPlayers;
 GVAR(mapInitialized) = false;
 
-waitUntil { !isNil QEGVAR(tracking_main,controlTypes) };
-EGVAR(tracking_main,controlTypes) pushBack [QGVAR(TextBoxNoMapClose),FUNC(initTextBoxNoMapClose)];
-EGVAR(tracking_main,controlTypes) pushBack [QGVAR(TextBoxNoMapCloseReadOnly),FUNC(initTextBoxNoMapClose)];
+[
+    {!isNil QEGVAR(tracking_main,controlTypes)},
+    {
+        EGVAR(tracking_main,controlTypes) pushBack [QGVAR(TextBoxNoMapClose),FUNC(initTextBoxNoMapClose)];
+        EGVAR(tracking_main,controlTypes) pushBack [QGVAR(TextBoxNoMapCloseReadOnly),FUNC(initTextBoxNoMapClose)];
 
-[] call FUNC(initMap);
-if(!EGVAR(rft,active)) then {
-    [] call MFUNC(initMap);
-};
+        [] call FUNC(initMap);
+        if(!EGVAR(rft,active)) then {
+            [] call MFUNC(initMap);
+        };
 
-[localize "STR_BFT_CONFIGURE", { HAS_TABLET }, FUNC(actionConfigure)] call MFUNC(addAction);
+        [localize "STR_BFT_CONFIGURE", { HAS_TABLET }, FUNC(actionConfigure)] call MFUNC(addAction);
+    }
+] call CBA_fnc_WaitUntilAndExecute;

--- a/dev/bft/functions/main/fn_init.sqf
+++ b/dev/bft/functions/main/fn_init.sqf
@@ -44,7 +44,7 @@ GVAR(configureUnits) = allPlayers;
 GVAR(mapInitialized) = false;
 
 [
-    {!isNil QEGVAR(tracking_main,controlTypes)},
+    {(!isNil QEGVAR(tracking_main,controlTypes)) && !((isNull player) or (isNull (finddisplay 46)))},
     {
         EGVAR(tracking_main,controlTypes) pushBack [QGVAR(TextBoxNoMapClose),FUNC(initTextBoxNoMapClose)];
         EGVAR(tracking_main,controlTypes) pushBack [QGVAR(TextBoxNoMapCloseReadOnly),FUNC(initTextBoxNoMapClose)];

--- a/dev/bft/functions/main/fn_initAssign.sqf
+++ b/dev/bft/functions/main/fn_initAssign.sqf
@@ -1,23 +1,29 @@
 #include "script_component.hpp"
 
-if(!hasInterface) exitWith {};
-waitUntil { !isNull findDisplay 46 };
-waitUntil { !isNull player };
+if (!hasInterface) exitWith {};
 
-params ["_callsign", "_frequency", "_symbol", "_size", "_units"];
+[
+    {
+        missionNamespace getVariable [QGVAR(initClient), false]
+    },
+    {
+        params ["_callsign", "_frequency", "_symbol", "_size", "_units"];
 
-{
-    if(local _x) then {
-        private ["_marker"];
-        _marker = _x getVariable [QGVAR(marker),NEW_MARKER];
+        {
+            if (local _x) then {
+                private ["_marker"];
+                _marker = _x getVariable [QGVAR(marker),NEW_MARKER];
 
-        MARKER_SET_UNIT(_marker, _x);
-        MARKER_SET_CALLSIGN(_marker, _callsign);
-        MARKER_SET_FREQUENCY(_marker, _frequency);
-        SET_ICON_PATH(MARKER_GET_ICON(_marker), _symbol);
-        SET_ICON_PATH(MARKER_GET_SIZE(_marker), _size);
+                MARKER_SET_UNIT(_marker, _x);
+                MARKER_SET_CALLSIGN(_marker, _callsign);
+                MARKER_SET_FREQUENCY(_marker, _frequency);
+                SET_ICON_PATH(MARKER_GET_ICON(_marker), _symbol);
+                SET_ICON_PATH(MARKER_GET_SIZE(_marker), _size);
 
-        _x setVariable [QGVAR(marker), _marker, true];
-        _x setVariable [QGVAR(drawMarker), true, true];
-    };
-} foreach _units;
+                _x setVariable [QGVAR(marker), _marker, true];
+                _x setVariable [QGVAR(drawMarker), true, true];
+            };
+        } foreach _units;
+    },
+    _this
+] call CBA_fnc_waitUntilAndExecute;

--- a/dev/bft/functions/main/fn_initClient.sqf
+++ b/dev/bft/functions/main/fn_initClient.sqf
@@ -32,6 +32,8 @@
                 {!isNil QEGVAR(rft,pfhGPS)},
                 {[] call _AddGpsPfh}
             ] call CBA_fnc_waitUntilAndExecute;
-        };        
+        };
+        
+        GVAR(initClient) = true;
     }
 ] call CBA_fnc_waitUntilAndExecute;

--- a/dev/bft/functions/main/fn_initClient.sqf
+++ b/dev/bft/functions/main/fn_initClient.sqf
@@ -7,7 +7,6 @@
         player setVariable [QGVAR(marker), NEW_MARKER, true];
 
         // GPS
-
         private _AddGpsPfh = {
             GVAR(pfhGPS) = [
                 {
@@ -27,12 +26,11 @@
             ] call CBA_fnc_addPerFrameHandler;
         };
 
-        if (missionNamespace getVariable [QEGVAR(rft,active), false]) then {
-            [
-                {!isNil QEGVAR(rft,pfhGPS)},
-                {[] call _AddGpsPfh}
-            ] call CBA_fnc_waitUntilAndExecute;
-        };
+        [
+            {!((missionNamespace getVariable [QEGVAR(rft,active), false]) && isNil QEGVAR(rft,pfhGPS))},
+            {[] call _this},
+            _addGpsPfh
+        ] call CBA_fnc_waitUntilAndExecute;
         
         GVAR(initClient) = true;
     }

--- a/dev/bft/functions/main/fn_initClient.sqf
+++ b/dev/bft/functions/main/fn_initClient.sqf
@@ -1,0 +1,37 @@
+#include "script_component.hpp"
+
+[
+    {!((isNull player) or (isNull (finddisplay 46)))},
+    {	// set player variables
+        player setVariable [QGVAR(drawMarker), false, true];
+        player setVariable [QGVAR(marker), NEW_MARKER, true];
+
+        // GPS
+
+        private _AddGpsPfh = {
+            GVAR(pfhGPS) = [
+                {
+                    private _finished = false;
+                    {
+                        if (ctrlIDD _x == 311) then {
+                            private _mapControl = _x displayCtrl 101;
+                            _mapControl ctrlAddEventHandler ["draw", FUNC(handleDraw)];
+                            _finished = true;
+                        };
+                    } forEach (uiNamespace getVariable "IGUI_displays");
+                    if (_finished) then {
+                        [_this select 1] call CBA_fnc_removePerFrameHandler;
+                    };
+                },
+                0,[]
+            ] call CBA_fnc_addPerFrameHandler;
+        };
+
+        if (missionNamespace getVariable [QEGVAR(rft,active), false]) then {
+            [
+                {!isNil QEGVAR(rft,pfhGPS)},
+                {[] call _AddGpsPfh}
+            ] call CBA_fnc_waitUntilAndExecute;
+        };        
+    }
+] call CBA_fnc_waitUntilAndExecute;

--- a/dev/bft/functions/main/fn_initModule.sqf
+++ b/dev/bft/functions/main/fn_initModule.sqf
@@ -1,3 +1,4 @@
 #include "script_component.hpp"
 
-call FUNC(init);
+// For backwards compatibility, run init by module, but only if it hasn't run before in preInit.
+if (!GVAR(active)) then call FUNC(init);

--- a/dev/bft/initSettings.sqf
+++ b/dev/bft/initSettings.sqf
@@ -1,0 +1,8 @@
+[
+	QGVAR(enable),
+	"CHECKBOX",
+	LLSTRING(Enable),
+	LELSTRING(tracking_main,name),
+	true,
+	1
+] call CBA_Settings_fnc_init;

--- a/dev/bft/stringtable.xml
+++ b/dev/bft/stringtable.xml
@@ -118,11 +118,6 @@
 			</Key>
 		</Container>
 		<Container ID="CfgVehicles">
-			<Key ID="STR_MODULE_BFT_NAME">
-				<Original>Enable Blue Force Tracking</Original>
-				<English>Enable Blue Force Tracking</English>
-				<German>Blue Force Tracking aktivieren</German>
-			</Key>
 			<Key ID="STR_MODULE_BFT_ASSIGN_NAME">
 				<Original>Assign BFT Information</Original>
 				<English>Assign BFT Information</English>
@@ -216,6 +211,13 @@
 				<Original>Configure BFT</Original>
 				<English>Configure BFT</English>
 				<German>BFT konfigurieren</German>
+			</Key>
+		</Container>
+		<Container ID="CBA Settings">
+			<Key ID="STR_CL_BFT_ENABLE">
+				<Original>Enable Red Force Tracking</Original>
+				<English>Enable Red Force Tracking</English>
+				<German>Red Force Tracking aktivieren</German>
 			</Key>
 		</Container>
 	</Package>

--- a/dev/rft/CfgFunctions.hpp
+++ b/dev/rft/CfgFunctions.hpp
@@ -20,6 +20,7 @@ class CfgFunctions {
             file = FUNCFILE(main);
 
             class init {};
+            class initClient {};
             class initModule {};
             class getMarkerIndex {};
             class dirToString {};

--- a/dev/rft/CfgVehicles.hpp
+++ b/dev/rft/CfgVehicles.hpp
@@ -8,8 +8,8 @@ class CfgVehicles {
     };
 
     class MODULE_RFT: Module_F {
-        scope = 2;
-        displayName = $STR_MODULE_RFT_NAME;
+        scope = 1;
+        displayName = CSTRING(Enable);
         icon = QDATAPATH(icon_module.paa);
         category = QUOTE(MODULE_CATEGORY);
         function = QUOTE(FUNC(initModule));

--- a/dev/rft/Extended_Eventhandlers.hpp
+++ b/dev/rft/Extended_Eventhandlers.hpp
@@ -1,7 +1,12 @@
 class Extended_Put_Eventhandlers {
     class Man {
         class GVAR(putTracker) {
-            put = _this call FUNC(xeh_handlePut);
+            put = QUOTE(_this call FUNC(xeh_handlePut));
         };
+    };
+};
+class Extended_PreInit_Eventhandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
     };
 };

--- a/dev/rft/XEH_preInit.sqf
+++ b/dev/rft/XEH_preInit.sqf
@@ -1,0 +1,8 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+#include "initSettings.sqf"
+if (GVAR(enable)) then { [] spawn FUNC(init); };
+
+ADDON = true;

--- a/dev/rft/functions/main/fn_init.sqf
+++ b/dev/rft/functions/main/fn_init.sqf
@@ -3,52 +3,26 @@
 GVAR(active) = true;
 
 // Client init
-if(hasInterface) then {
-    waitUntil { !isNull player };
-    waitUntil { !isNull (finddisplay 46) };
-
-    // JIP
-    GVAR(markers) = [missionNamespace, QGVAR(markers), []] call BIS_fnc_getServerVariable;
-    GVAR(currentMarkerID) = [missionNamespace, QGVAR(currentMarkerID), 0] call BIS_fnc_getServerVariable;
-
-    {
-        SET_MARKER(MARKER_GET_ID(_x), _x);
-    } foreach GVAR(markers);
-
-    // GPS
-    GVAR(pfhGPS) = [
-        {
-            _finished = false;
-            {
-                if(ctrlIDD _x == 311) then {
-                    _mapControl = _x displayCtrl 101;
-                    _mapControl ctrlAddEventHandler ["draw", FUNC(handleDraw)];
-                    _finished = true;
-                };
-            } forEach (uiNamespace getVariable "IGUI_displays");
-            if(_finished) then {
-                [_this select 1] call CBA_fnc_removePerFrameHandler;
-            };
-        },0,[]
-    ] call CBA_fnc_addPerFrameHandler;
+if (hasInterface) then {
+    [] call FUNC(initClient);
 };
 
 // Global variables for client and server
 GVAR(symbols) = [
-    [QMAINDATAPATH(symbols\unknown.paa),         localize "STR_RFT_UNKNOWN",                 { [QMAINDATAPATH(symbols\unknown.paa)] call FUNC(setSymbol); }],
-    [QMAINDATAPATH(symbols\inf.paa),             localize "STR_RFT_INF",                { [QMAINDATAPATH(symbols\inf.paa)] call FUNC(setSymbol); }],
+    [QMAINDATAPATH(symbols\unknown.paa),         localize "STR_RFT_UNKNOWN",     { [QMAINDATAPATH(symbols\unknown.paa)] call FUNC(setSymbol); }],
+    [QMAINDATAPATH(symbols\inf.paa),             localize "STR_RFT_INF",         { [QMAINDATAPATH(symbols\inf.paa)] call FUNC(setSymbol); }],
     [QMAINDATAPATH(symbols\motinf.paa),          localize "STR_RFT_MOTINF",      { [QMAINDATAPATH(symbols\motinf.paa)] call FUNC(setSymbol); }],
     [QMAINDATAPATH(symbols\mechinf.paa),         localize "STR_RFT_MECHINF",     { [QMAINDATAPATH(symbols\mechinf.paa)] call FUNC(setSymbol); }],
-    [QMAINDATAPATH(symbols\recon.paa),           localize "STR_RFT_RECON",                   { [QMAINDATAPATH(symbols\recon.paa)] call FUNC(setSymbol); }],
-    [QMAINDATAPATH(symbols\hq.paa),              localize "STR_RFT_HQ",                      { [QMAINDATAPATH(symbols\hq.paa)] call FUNC(setSymbol); }],
-    [QMAINDATAPATH(symbols\armor.paa),           localize "STR_RFT_ARMOR",                   { [QMAINDATAPATH(symbols\armor.paa)] call FUNC(setSymbol); }],
-    [QMAINDATAPATH(symbols\artillery.paa),       localize "STR_RFT_ARTILLERY",               { [QMAINDATAPATH(symbols\artillery.paa)] call FUNC(setSymbol); }],
-    [QMAINDATAPATH(symbols\heli.paa),            localize "STR_RFT_HELI",                    { [QMAINDATAPATH(symbols\heli.paa)] call FUNC(setSymbol); }],
-    [QMAINDATAPATH(symbols\jet.paa),             localize "STR_RFT_JET",                     { [QMAINDATAPATH(symbols\jet.paa)] call FUNC(setSymbol); }],
-    [QMAINDATAPATH(symbols\uav.paa),             localize "STR_RFT_UAV",                     { [QMAINDATAPATH(symbols\uav.paa)] call FUNC(setSymbol); }],
-    [QMAINDATAPATH(symbols\logistics.paa),       localize "STR_RFT_LOGISTICS",               { [QMAINDATAPATH(symbols\logistics.paa)] call FUNC(setSymbol); }],
-    [QMAINDATAPATH(symbols\medical.paa),         localize "STR_RFT_MEDICAL",                 { [QMAINDATAPATH(symbols\medical.paa)] call FUNC(setSymbol); }],
-    [QMAINDATAPATH(symbols\static.paa),          localize "STR_RFT_STATIC",                  { [QMAINDATAPATH(symbols\static.paa)] call FUNC(setSymbol); }]
+    [QMAINDATAPATH(symbols\recon.paa),           localize "STR_RFT_RECON",       { [QMAINDATAPATH(symbols\recon.paa)] call FUNC(setSymbol); }],
+    [QMAINDATAPATH(symbols\hq.paa),              localize "STR_RFT_HQ",          { [QMAINDATAPATH(symbols\hq.paa)] call FUNC(setSymbol); }],
+    [QMAINDATAPATH(symbols\armor.paa),           localize "STR_RFT_ARMOR",       { [QMAINDATAPATH(symbols\armor.paa)] call FUNC(setSymbol); }],
+    [QMAINDATAPATH(symbols\artillery.paa),       localize "STR_RFT_ARTILLERY",   { [QMAINDATAPATH(symbols\artillery.paa)] call FUNC(setSymbol); }],
+    [QMAINDATAPATH(symbols\heli.paa),            localize "STR_RFT_HELI",        { [QMAINDATAPATH(symbols\heli.paa)] call FUNC(setSymbol); }],
+    [QMAINDATAPATH(symbols\jet.paa),             localize "STR_RFT_JET",         { [QMAINDATAPATH(symbols\jet.paa)] call FUNC(setSymbol); }],
+    [QMAINDATAPATH(symbols\uav.paa),             localize "STR_RFT_UAV",         { [QMAINDATAPATH(symbols\uav.paa)] call FUNC(setSymbol); }],
+    [QMAINDATAPATH(symbols\logistics.paa),       localize "STR_RFT_LOGISTICS",   { [QMAINDATAPATH(symbols\logistics.paa)] call FUNC(setSymbol); }],
+    [QMAINDATAPATH(symbols\medical.paa),         localize "STR_RFT_MEDICAL",     { [QMAINDATAPATH(symbols\medical.paa)] call FUNC(setSymbol); }],
+    [QMAINDATAPATH(symbols\static.paa),          localize "STR_RFT_STATIC",      { [QMAINDATAPATH(symbols\static.paa)] call FUNC(setSymbol); }]
 ];
 
 GVAR(colors) = [
@@ -114,14 +88,18 @@ GVAR(favorites) = [
     [QMAINDATAPATH(symbols\unknown.paa), SIZE_UNIT, [COLOR_GREY]]
 ];
 
-waitUntil { !isNil QEGVAR(tracking_main,controlTypes); };
-EGVAR(tracking_main,controlTypes) pushBack [QGVAR(FavContainer),FUNC(initFavContainer)];
+[
+    {!isNil QEGVAR(tracking_main,controlTypes)},
+    {
+        EGVAR(tracking_main,controlTypes) pushBack [QGVAR(FavContainer),FUNC(initFavContainer)];
 
-// Map init
-[] call FUNC(initMap);
-[] call MFUNC(initMap);
+        // Map init
+        [] call FUNC(initMap);
+        [] call MFUNC(initMap);
 
-// syncing
-QGVAR(packet) addPublicVariableEventHandler {
-    (_this select 1) call FUNC(syncMarker);
-};
+        // syncing
+        QGVAR(packet) addPublicVariableEventHandler {
+            (_this select 1) call FUNC(syncMarker);
+        };
+    }
+] call CBA_fnc_waitUntilAndExecute;

--- a/dev/rft/functions/main/fn_init.sqf
+++ b/dev/rft/functions/main/fn_init.sqf
@@ -89,7 +89,7 @@ GVAR(favorites) = [
 ];
 
 [
-    {!isNil QEGVAR(tracking_main,controlTypes)},
+    {(!isNil QEGVAR(tracking_main,controlTypes)) && !((isNull player) or (isNull (finddisplay 46)))},
     {
         EGVAR(tracking_main,controlTypes) pushBack [QGVAR(FavContainer),FUNC(initFavContainer)];
 

--- a/dev/rft/functions/main/fn_initClient.sqf
+++ b/dev/rft/functions/main/fn_initClient.sqf
@@ -1,30 +1,31 @@
 #include "script_component.hpp"
 
 [
-	{!((isNull player) or (isNull (finddisplay 46)))},
-	{	// JIP
-		[missionNamespace, QGVAR(markers), []] spawn BIS_fnc_getServerVariable;
-		[missionNamespace, QGVAR(currentMarkerID), 0] spawn BIS_fnc_getServerVariable;
+    {!((isNull player) or (isNull (finddisplay 46)))},
+    {	// JIP
+        private _getMarkers = [missionNamespace, QGVAR(markers), []] spawn BIS_fnc_getServerVariable;
+        [{scriptDone _getMarkers}, {
+            { SET_MARKER(MARKER_GET_ID(_x), _x) } foreach GVAR(markers);
+        }] call CBA_fnc_waitUntilAndExecute;
+        [missionNamespace, QGVAR(currentMarkerID), 0] spawn BIS_fnc_getServerVariable;
 
-		{
-			SET_MARKER(MARKER_GET_ID(_x), _x);
-		} foreach GVAR(markers);
 
-		// GPS
-		GVAR(pfhGPS) = [
-			{
-				_finished = false;
-				{
-					if(ctrlIDD _x == 311) then {
-						_mapControl = _x displayCtrl 101;
-						_mapControl ctrlAddEventHandler ["draw", FUNC(handleDraw)];
-						_finished = true;
-					};
-				} forEach (uiNamespace getVariable "IGUI_displays");
-				if(_finished) then {
-					[_this select 1] call CBA_fnc_removePerFrameHandler;
-				};
-			},0,[]
-		] call CBA_fnc_addPerFrameHandler;
-	}
+
+        // GPS
+        GVAR(pfhGPS) = [
+            {
+                _finished = false;
+                {
+                    if(ctrlIDD _x == 311) then {
+                        _mapControl = _x displayCtrl 101;
+                        _mapControl ctrlAddEventHandler ["draw", FUNC(handleDraw)];
+                        _finished = true;
+                    };
+                } forEach (uiNamespace getVariable "IGUI_displays");
+                if(_finished) then {
+                    [_this select 1] call CBA_fnc_removePerFrameHandler;
+                };
+            },0,[]
+        ] call CBA_fnc_addPerFrameHandler;
+    }
 ] call CBA_fnc_waitUntilAndExecute;

--- a/dev/rft/functions/main/fn_initClient.sqf
+++ b/dev/rft/functions/main/fn_initClient.sqf
@@ -9,8 +9,6 @@
         }] call CBA_fnc_waitUntilAndExecute;
         [missionNamespace, QGVAR(currentMarkerID), 0] spawn BIS_fnc_getServerVariable;
 
-
-
         // GPS
         GVAR(pfhGPS) = [
             {

--- a/dev/rft/functions/main/fn_initClient.sqf
+++ b/dev/rft/functions/main/fn_initClient.sqf
@@ -1,0 +1,30 @@
+#include "script_component.hpp"
+
+[
+	{!((isNull player) or (isNull (finddisplay 46)))},
+	{	// JIP
+		[missionNamespace, QGVAR(markers), []] spawn BIS_fnc_getServerVariable;
+		[missionNamespace, QGVAR(currentMarkerID), 0] spawn BIS_fnc_getServerVariable;
+
+		{
+			SET_MARKER(MARKER_GET_ID(_x), _x);
+		} foreach GVAR(markers);
+
+		// GPS
+		GVAR(pfhGPS) = [
+			{
+				_finished = false;
+				{
+					if(ctrlIDD _x == 311) then {
+						_mapControl = _x displayCtrl 101;
+						_mapControl ctrlAddEventHandler ["draw", FUNC(handleDraw)];
+						_finished = true;
+					};
+				} forEach (uiNamespace getVariable "IGUI_displays");
+				if(_finished) then {
+					[_this select 1] call CBA_fnc_removePerFrameHandler;
+				};
+			},0,[]
+		] call CBA_fnc_addPerFrameHandler;
+	}
+] call CBA_fnc_waitUntilAndExecute;

--- a/dev/rft/functions/main/fn_initModule.sqf
+++ b/dev/rft/functions/main/fn_initModule.sqf
@@ -1,3 +1,4 @@
 #include "script_component.hpp"
 
-call FUNC(init);
+// For backwards compatibility, run init by module, but only if it hasn't run before in preInit.
+if (!GVAR(active)) then call FUNC(init);

--- a/dev/rft/initSettings.sqf
+++ b/dev/rft/initSettings.sqf
@@ -1,0 +1,8 @@
+[
+	QGVAR(enable),
+	"CHECKBOX",
+	LLSTRING(Enable),
+	LELSTRING(tracking_main,name),
+	true,
+	1
+] call CBA_Settings_fnc_init;

--- a/dev/rft/stringtable.xml
+++ b/dev/rft/stringtable.xml
@@ -191,13 +191,6 @@
 				<German>Benutzerdefiniert</German>
 			</Key>
 		</Container>
-		<Container ID="CfgVehicles">
-			<Key ID="STR_MODULE_RFT_NAME">
-				<Original>Enable Red Force Tracking</Original>
-				<English>Enable Red Force Tracking</English>
-				<German>Red Force Tracking aktivieren</German>
-			</Key>
-		</Container>
 		<Container ID="dialog">
 			<Key ID="STR_RFT_LBL_TEXTID">
 				<Original>ID:</Original>
@@ -230,6 +223,13 @@
 				<Original>Configure RFT</Original>
 				<English>Configure RFT</English>
 				<German>RFT konfigurieren</German>
+			</Key>
+		</Container>
+		<Container ID="CBA Settings">
+			<Key ID="STR_CL_RFT_ENABLE">
+				<Original>Enable Red Force Tracking</Original>
+				<English>Enable Red Force Tracking</English>
+				<German>Red Force Tracking aktivieren</German>
 			</Key>
 		</Container>
 	</Package>

--- a/dev/tracking_main/stringtable.xml
+++ b/dev/tracking_main/stringtable.xml
@@ -7,6 +7,11 @@
 				<English>EasyTrack</English>
 				<German>EasyTrack</German>
 			</Key>
+			<Key ID="STR_CL_TRACKING_MAIN_NAME">
+				<Original>EasyTrack</Original>
+				<English>EasyTrack</English>
+				<German>EasyTrack</German>
+			</Key>
 		</Container>
 		<Container ID="Actions">
 			<Key ID="STR_MAIN_SELFDESTRUCT">


### PR DESCRIPTION
* Use CBA Settings System instead of modules for enabling/disabling RFT & BFT.
* Hide the deprecated modules.
* Keep functionality of modules for backwards compatibility.

Für Gruppe W abgesprochen mit Soldia.